### PR TITLE
TodoApp 회원가입 및 Spring Security + JWT Token 인증 방식 로그인 Api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,34 @@ dependencies {
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	//v4
+	//spring-security
+	//swagger
+	implementation 'io.springfox:springfox-boot-starter:3.0.0'
+	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+
+	//modelMapper
+	implementation group: 'org.modelmapper', name: 'modelmapper', version :  '2.3.8'
+
+
+	compileOnly 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5',
+			// Uncomment the next line if you want to use RSASSA-PSS (PS256, PS384, PS512) algorithms:
+			//'org.bouncycastle:bcprov-jdk15on:1.70',
+			'io.jsonwebtoken:jjwt-jackson:0.11.5' // or 'io.jsonwebtoken:jjwt-gson:0.11.5' for gson
+
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	testImplementation 'org.springframework.security:spring-security-test'
+
+	implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+
+	implementation 'com.sun.xml.bind:jaxb-impl:4.0.1'
+	implementation 'com.sun.xml.bind:jaxb-core:4.0.1'
+
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/co/ajoutee/TodoteeApplication.java
+++ b/src/main/java/kr/co/ajoutee/TodoteeApplication.java
@@ -2,6 +2,7 @@ package kr.co.ajoutee;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication

--- a/src/main/java/kr/co/ajoutee/todotee/controller/TodoController.java
+++ b/src/main/java/kr/co/ajoutee/todotee/controller/TodoController.java
@@ -1,18 +1,22 @@
 package kr.co.ajoutee.todotee.controller;
 
 import jakarta.validation.Valid;
-import kr.co.ajoutee.domain.TodoEntity;
+import kr.co.ajoutee.todotee.domain.TodoEntity;
 import kr.co.ajoutee.todotee.dto.TodoRequestDto;
 import kr.co.ajoutee.todotee.dto.TodoResponseDto;
-import kr.co.ajoutee.service.TodoService;
+import kr.co.ajoutee.todotee.service.TodoService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
-@RequestMapping("/")
+@RequestMapping("/todos")
 @RequiredArgsConstructor
+@Slf4j
 public class TodoController {
     private final TodoService todoService;
 
@@ -25,9 +29,17 @@ public class TodoController {
         return new ResponseEntity<>(todoResponseDto, HttpStatus.CREATED);
     }
 
+    @GetMapping("")
+    public ResponseEntity<List<TodoResponseDto>> searchAll() {
+        List<TodoEntity> result = todoService.searchAll();
+        List<TodoResponseDto> todoList = result.stream().map(e -> TodoResponseDto.of(e)).toList();
+        return new ResponseEntity<>(todoList, HttpStatus.OK);
+    }
+
 
     @GetMapping("{id}")
-    public ResponseEntity<TodoResponseDto> searchById(@PathVariable Long id) {
+    public ResponseEntity<TodoResponseDto> searchById(@PathVariable Long id, @Valid @RequestBody TodoRequestDto todoRequestDto ) {
+        log.info("id = {}, title = {}, completed = {}", id, todoRequestDto.getTitle(), todoRequestDto.getCompleted());
         TodoEntity result = todoService.searchById(id);
         TodoResponseDto todoResponseDto = TodoResponseDto.of(result);
         return new ResponseEntity<>(todoResponseDto, HttpStatus.OK);

--- a/src/main/java/kr/co/ajoutee/todotee/domain/BasicEntity.java
+++ b/src/main/java/kr/co/ajoutee/todotee/domain/BasicEntity.java
@@ -1,4 +1,4 @@
-package kr.co.ajoutee.domain;
+package kr.co.ajoutee.todotee.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/kr/co/ajoutee/todotee/domain/TodoEntity.java
+++ b/src/main/java/kr/co/ajoutee/todotee/domain/TodoEntity.java
@@ -1,4 +1,4 @@
-package kr.co.ajoutee.domain;
+package kr.co.ajoutee.todotee.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
@@ -15,16 +15,14 @@ public class TodoEntity extends BasicEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    @NonNull
+    @Column()
     private String title;
 
 
-    @Column(updatable = false)
+    @Column()
     private Boolean completed;
-//    true false
 
-    @Column(updatable = false)
+    @Column()
     private LocalDateTime complete_at;
 
     @Builder

--- a/src/main/java/kr/co/ajoutee/todotee/dto/TodoRequestDto.java
+++ b/src/main/java/kr/co/ajoutee/todotee/dto/TodoRequestDto.java
@@ -2,7 +2,7 @@ package kr.co.ajoutee.todotee.dto;
 
 
 import jakarta.validation.constraints.NotEmpty;
-import kr.co.ajoutee.domain.TodoEntity;
+import kr.co.ajoutee.todotee.domain.TodoEntity;
 import lombok.*;
 
 import java.util.Date;
@@ -19,7 +19,7 @@ public class TodoRequestDto {
     public TodoEntity toEntity() {
         return TodoEntity.builder()
                 .title(title)
-                .completed(true)
+                .completed(completed)
                 .build();
     }
 

--- a/src/main/java/kr/co/ajoutee/todotee/dto/TodoResponseDto.java
+++ b/src/main/java/kr/co/ajoutee/todotee/dto/TodoResponseDto.java
@@ -2,7 +2,7 @@ package kr.co.ajoutee.todotee.dto;
 
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import kr.co.ajoutee.domain.TodoEntity;
+import kr.co.ajoutee.todotee.domain.TodoEntity;
 import lombok.*;
 
 import java.time.LocalDateTime;

--- a/src/main/java/kr/co/ajoutee/todotee/repository/TodoJpaRepository.java
+++ b/src/main/java/kr/co/ajoutee/todotee/repository/TodoJpaRepository.java
@@ -1,6 +1,6 @@
-package kr.co.ajoutee.repository;
+package kr.co.ajoutee.todotee.repository;
 
-import kr.co.ajoutee.domain.TodoEntity;
+import kr.co.ajoutee.todotee.domain.TodoEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/kr/co/ajoutee/todotee/security/SecurityConfig.java
+++ b/src/main/java/kr/co/ajoutee/todotee/security/SecurityConfig.java
@@ -1,0 +1,103 @@
+package kr.co.ajoutee.todotee.security;
+
+
+import kr.co.ajoutee.todotee.security.jwt.CorsFilterConfig;
+import kr.co.ajoutee.todotee.security.jwt.JwtAuthenticationFilter;
+import kr.co.ajoutee.todotee.security.jwt.exception.JwtAccessDeniedHandler;
+import kr.co.ajoutee.todotee.security.jwt.exception.JwtAuthenticationEntryPoint;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
+
+import java.util.stream.Stream;
+
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+//    @Value("${jwt.secret}")
+//    private String secretKey;
+//    private final JwtTokenProvider tokenProvider;
+    private final CorsFilterConfig corsFilterConfig;
+    private final AuthenticationProvider authenticationProvider;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+
+    private static final String[] PERMIT_URL_ARRAY = {"/error"};
+
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, HandlerMappingIntrospector introspector) throws Exception {
+
+
+        return http
+                .httpBasic(httpBasic -> httpBasic.disable()) //
+                .csrf(AbstractHttpConfigurer::disable)
+                //h2 database 사용을 위한 xFrameOption 설정
+                .headers(header -> header.frameOptions(
+                                        frameOptionsConfig -> frameOptionsConfig.disable()))
+                //여러 필터를 사용 중이라면 CorsFilter를 제일 앞에 설정
+                .addFilterBefore(corsFilterConfig.corsFilter(), UsernamePasswordAuthenticationFilter.class)
+                //에러 커스텀 설정
+                .exceptionHandling(authenticationManager -> authenticationManager
+                        .accessDeniedHandler(new JwtAccessDeniedHandler())
+                        .authenticationEntryPoint(new JwtAuthenticationEntryPoint())
+                )
+                // form 기반의 로그인에 대해 비 활성화하며 커스텀으로 구성한 필터 사용
+                .formLogin(httpSecurityFormLoginConfigurer -> httpSecurityFormLoginConfigurer.disable())
+                //Session 기반의 인증기반을 사용하지 않기 위한 설정
+                .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authenticationProvider(authenticationProvider)
+                //토큰을 활용하는 경우 모든 요청에 대해 '인가'에 대해서 사용.
+                .authorizeHttpRequests(authorize ->
+                        authorize
+                                //h2 console 활용을 위한 인가 설정
+                                .requestMatchers(PathRequest.toH2Console()).permitAll()
+                                // URL 패턴별로 접근 권한 설정을 위한 Antrequestmathcher 사용
+                                .requestMatchers(new AntPathRequestMatcher("/jwt-login/**")).permitAll()
+//                                .requestMatchers("/","/**").permitAll()
+//                                .requestMatchers("jwt-login/**").permitAll()
+//                                .requestMatchers(PERMIT_URL_ARRAY).permitAll()
+//                                .requestMatchers(new MvcRequestMatcher(introspector,"/**")).permitAll()
+//                                .anyRequest().hasRole("USER")
+
+
+                )
+
+                // 커스텀 인가 필터 추가
+                .addFilterBefore(jwtAuthenticationFilter,
+                UsernamePasswordAuthenticationFilter.class)
+                .build();
+
+    }
+
+    @Bean
+    public BCryptPasswordEncoder encoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+}

--- a/src/main/java/kr/co/ajoutee/todotee/security/jwt/ApplicationConfig.java
+++ b/src/main/java/kr/co/ajoutee/todotee/security/jwt/ApplicationConfig.java
@@ -1,0 +1,44 @@
+package kr.co.ajoutee.todotee.security.jwt;
+import kr.co.ajoutee.todotee.signup.repository.MemberJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@RequiredArgsConstructor
+public class ApplicationConfig {
+
+    private final MemberJpaRepository repository;
+
+    @Bean
+    UserDetailsService userDetailsService() {
+        return username -> repository.findByLoginId(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+    }
+
+    @Bean
+    AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(userDetailsService());
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
+    }
+
+    @Bean
+    AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/kr/co/ajoutee/todotee/security/jwt/CorsFilterConfig.java
+++ b/src/main/java/kr/co/ajoutee/todotee/security/jwt/CorsFilterConfig.java
@@ -1,0 +1,41 @@
+package kr.co.ajoutee.todotee.security.jwt;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+import java.util.Arrays;
+
+@Configuration
+public class CorsFilterConfig {
+
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOrigin("*");
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        source.registerCorsConfiguration("/jwt-login/**", config);
+        return new CorsFilter(source);
+    }
+
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
+        corsConfiguration.setAllowedOrigins(Arrays.asList("https://127.0.0.1"));
+        corsConfiguration.setAllowedMethods(Arrays.asList("GET", "POST"));
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", corsConfiguration);
+        return source;
+
+
+
+    }
+}

--- a/src/main/java/kr/co/ajoutee/todotee/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/co/ajoutee/todotee/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package kr.co.ajoutee.todotee.security.jwt;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+    @Component
+    @RequiredArgsConstructor
+    public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+        private final JwtService jwtService;
+        private final UserDetailsService userDetailsService;
+
+        @Override
+        protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+                throws ServletException, IOException {
+            final String authHeader = request.getHeader("Authorization");
+            final String jwt;
+            final String loginId;
+            if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+            jwt = authHeader.substring(7);
+            loginId = jwtService.extractUsername(jwt);
+            if(loginId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UserDetails userDetails = userDetailsService.loadUserByUsername(loginId);
+                if (jwtService.isTokenValid(jwt, userDetails)) {
+                    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities()
+                    );
+                    authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authToken);
+                }
+            }
+            filterChain.doFilter(request, response);
+        }
+    }

--- a/src/main/java/kr/co/ajoutee/todotee/security/jwt/JwtService.java
+++ b/src/main/java/kr/co/ajoutee/todotee/security/jwt/JwtService.java
@@ -1,0 +1,72 @@
+package kr.co.ajoutee.todotee.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
+import java.util.function.Function;
+
+@Service
+public class JwtService {
+
+    private static final String SECRET_KEY = "77397A244326462948404D635166546A576E5A7234753778214125442A472D4B";
+
+    public String extractUsername(String token) {
+        return extractClaim(token, Claims::getSubject);
+    }
+
+    public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = extractAllClaims(token);
+        return claimsResolver.apply(claims);
+    }
+
+    public String generateToken(UserDetails userDetails) {
+        return generateToken(Map.of(), userDetails);
+    }
+
+    public String generateToken(Map<String, Object> extraClaims, UserDetails userDetails) {
+        return Jwts
+                .builder()
+                .setClaims(extraClaims)
+                .setSubject(userDetails.getUsername())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 24)) // 1 day
+                .signWith(getSignInKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean isTokenValid(String token, UserDetails userDetails) {
+        final String username = extractUsername(token);
+        return (username.equals(userDetails.getUsername()) && !isTokenExpired(token));
+    }
+
+    private boolean isTokenExpired(String token) {
+        return extractExpiration(token).before(new Date());
+    }
+
+    private Date extractExpiration(String token) {
+        return extractClaim(token, Claims::getExpiration);
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts
+                .parserBuilder()
+                .setSigningKey(getSignInKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    private Key getSignInKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(SECRET_KEY);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+}

--- a/src/main/java/kr/co/ajoutee/todotee/security/jwt/exception/JwtAccessDeniedHandler.java
+++ b/src/main/java/kr/co/ajoutee/todotee/security/jwt/exception/JwtAccessDeniedHandler.java
@@ -1,0 +1,16 @@
+package kr.co.ajoutee.todotee.security.jwt.exception;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN); //401에러
+    }
+}

--- a/src/main/java/kr/co/ajoutee/todotee/security/jwt/exception/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/kr/co/ajoutee/todotee/security/jwt/exception/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,20 @@
+package kr.co.ajoutee.todotee.security.jwt.exception;
+
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+@Configuration
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, org.springframework.security.core.AuthenticationException authException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);//401에러
+
+    }
+}

--- a/src/main/java/kr/co/ajoutee/todotee/service/TodoService.java
+++ b/src/main/java/kr/co/ajoutee/todotee/service/TodoService.java
@@ -1,7 +1,7 @@
-package kr.co.ajoutee.service;
+package kr.co.ajoutee.todotee.service;
 
-import kr.co.ajoutee.domain.TodoEntity;
-import kr.co.ajoutee.repository.TodoJpaRepository;
+import kr.co.ajoutee.todotee.domain.TodoEntity;
+import kr.co.ajoutee.todotee.repository.TodoJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -37,6 +37,7 @@ public class TodoService {
     @Transactional
     public void updateTodo(TodoEntity todo, String title, Boolean completed) {
         todo.update(title, completed);
+        todoRepository.save(todo);
     }
 
     @Transactional

--- a/src/main/java/kr/co/ajoutee/todotee/signup/controller/MemberController.java
+++ b/src/main/java/kr/co/ajoutee/todotee/signup/controller/MemberController.java
@@ -1,0 +1,36 @@
+package kr.co.ajoutee.todotee.signup.controller;
+
+import kr.co.ajoutee.todotee.signup.dto.TokenInfo;
+import kr.co.ajoutee.todotee.signup.service.MemberService;
+import kr.co.ajoutee.todotee.signup.dto.LoginDto;
+import kr.co.ajoutee.todotee.signup.dto.MemberFormDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/jwt-login")
+@CrossOrigin
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService service;
+
+    // 로그인
+    @PostMapping("/login")
+    public ResponseEntity<TokenInfo> login(@RequestBody LoginDto registerRequestDto) {
+        return ResponseEntity.ok(service.login(registerRequestDto));
+    }
+
+    //회원가입
+    @PostMapping("/register")
+    public ResponseEntity<TokenInfo> register(@RequestBody MemberFormDto registerRequestDto) {
+        return ResponseEntity.ok(service.register(registerRequestDto));
+    }
+
+
+}
+
+
+
+

--- a/src/main/java/kr/co/ajoutee/todotee/signup/dto/LoginDto.java
+++ b/src/main/java/kr/co/ajoutee/todotee/signup/dto/LoginDto.java
@@ -1,0 +1,17 @@
+package kr.co.ajoutee.todotee.signup.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoginDto {
+
+    private String loginId;
+    private String pwd;
+}

--- a/src/main/java/kr/co/ajoutee/todotee/signup/dto/MemberFormDto.java
+++ b/src/main/java/kr/co/ajoutee/todotee/signup/dto/MemberFormDto.java
@@ -1,0 +1,23 @@
+package kr.co.ajoutee.todotee.signup.dto;
+
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberFormDto {
+
+
+    @NotBlank
+    private String loginId;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String pwd;
+
+
+}

--- a/src/main/java/kr/co/ajoutee/todotee/signup/dto/TokenInfo.java
+++ b/src/main/java/kr/co/ajoutee/todotee/signup/dto/TokenInfo.java
@@ -1,0 +1,14 @@
+package kr.co.ajoutee.todotee.signup.dto;
+
+import lombok.*;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TokenInfo {
+
+    private String accessToken;
+//    private String refreshToken; // 추후 추가 예정
+
+}

--- a/src/main/java/kr/co/ajoutee/todotee/signup/model/Member.java
+++ b/src/main/java/kr/co/ajoutee/todotee/signup/model/Member.java
@@ -1,0 +1,62 @@
+package kr.co.ajoutee.todotee.signup.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Member implements UserDetails {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String loginId;
+    private String pwd;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(role.name()));
+    }
+
+
+    @Override
+    public String getUsername() {
+        return loginId;
+    }
+
+    @Override
+    public String getPassword() {
+        return pwd;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/kr/co/ajoutee/todotee/signup/model/Role.java
+++ b/src/main/java/kr/co/ajoutee/todotee/signup/model/Role.java
@@ -1,0 +1,6 @@
+package kr.co.ajoutee.todotee.signup.model;
+
+public enum Role {
+
+    USER, ADMIN
+}

--- a/src/main/java/kr/co/ajoutee/todotee/signup/repository/MemberJpaRepository.java
+++ b/src/main/java/kr/co/ajoutee/todotee/signup/repository/MemberJpaRepository.java
@@ -1,0 +1,16 @@
+package kr.co.ajoutee.todotee.signup.repository;
+
+import kr.co.ajoutee.todotee.signup.model.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberJpaRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByLoginId(String loginId);
+
+}
+
+

--- a/src/main/java/kr/co/ajoutee/todotee/signup/service/MemberService.java
+++ b/src/main/java/kr/co/ajoutee/todotee/signup/service/MemberService.java
@@ -1,0 +1,58 @@
+package kr.co.ajoutee.todotee.signup.service;
+
+import kr.co.ajoutee.todotee.security.jwt.JwtService;
+import kr.co.ajoutee.todotee.signup.dto.LoginDto;
+import kr.co.ajoutee.todotee.signup.dto.MemberFormDto;
+import kr.co.ajoutee.todotee.signup.dto.TokenInfo;
+import kr.co.ajoutee.todotee.signup.model.Member;
+import kr.co.ajoutee.todotee.signup.model.Role;
+import kr.co.ajoutee.todotee.signup.repository.MemberJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final PasswordEncoder encoder;
+    private final MemberJpaRepository repository;
+
+    private final JwtService jwtService;
+
+    private final AuthenticationManager authenticationManager;
+
+
+
+
+    public TokenInfo login(LoginDto request) {
+        authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getLoginId(), request.getPwd())
+        );
+        var user = repository.findByLoginId(request.getLoginId()).orElseThrow();
+        var jwt = jwtService.generateToken(user);
+        return TokenInfo.builder()
+                .accessToken(jwt)
+                .build();
+    }
+
+    public TokenInfo register(MemberFormDto request) {
+        var user = Member.builder()
+                .loginId(request.getLoginId())
+                .pwd(encoder.encode(request.getPwd()))
+                .role(Role.USER)
+                .build();
+        repository.save(user);
+        var jwt = jwtService.generateToken(user);
+        return TokenInfo.builder()
+                .accessToken(jwt)
+                .build();
+    }
+
+
+
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,31 @@
-spring:
-  datasource:
-    url: jdbc:mariadb://localhost:3306/TodoDB
-    username: jju
-    password: 1234
-    driver-class-name: org.mariadb.jdbc.Driver
-  jpa:
-    generate-ddl : false
+#spring:
+#  datasource:
+#    url: jdbc:mariadb://localhost:3306/TodoDB
+#    username: jju
+#    password: 1234
+#    driver-class-name: org.mariadb.jdbc.Driver
+#  jpa:
+#    generate-ddl : false
+#
+#    hibernate:
+#      ddl-auto: update
 
+spring:
+
+  h2:
+    console:
+      enabled: true
+
+  datasource:
+    url: jdbc:h2:mem:TodoDB
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: update # SessionFactoryr가 시작될 때 Drop, Create, Alter 종료될 때 Drop
+
 
 


### PR DESCRIPTION
회원가입 방식은 아이디와 패스워드만을 변수로 만들었습니다.  현재는 회원가입을 하여도 accessToken이 발행되는데 추후 멤버 정보를 반환할 것인지 아니면 status code를 반환할 것인지 논의 후에 변경하도록 하겠습니다.(추후 논의 후 더 많은 변수 추가 해보겠습니다.)
로그인 방식은 JwtAuthenticationFilter를 적용한 필터를 이용하여 JWT가 발행한 access토큰을 반환하도록 구현하였습니다. (추후 refresh token 발행도 추가하겠습니다.)

Member 객체, 회원가입 Dto ('MemberFormDto') , 로그인 Dto , 토큰 Dto 그리고 회원가입과 로그인을 수행하는 Service , controller 로 구성되어 있습니다.
JwtAuthenticationFilter는 JWT 토큰으로 인증하고 SecurityContextHolder에 추가하는 필터를 설정하는 클래스로 OncePerRequestFilter를 사용함으로써 인증이나 인가를 한번만 거치고 다음 로직을 진행할 수 있도록 했습니다.
JwtService 는 JWT token을 생성하고, claim에 담긴 정보를 추출하는 메소드를 개발한 클래스입니다.

ApplicationConfig에는 ID/PW 인증을 위한 passwordencoder(사용자 비밀번호 암호화) 와 userDetailsService, filter로부터 인증처리를 지시받고 적절한 provider에게 인증처리를 맡기는 AuthenticationManager,  ID와 Password를 검증하는 AuthenticationProvider 메소드로 구현해놓은 클래스입니다. 
(처음에는 따로 커스텀 클래스로 전부 만들었다가 복잡해지고 인증처리가 잘 되지 않아 공부하고 다시 구현해놓았습니다..)
Cors를 허용하는 Corsfilter가 있습니다.(현재 코드에서는 없어도 동작합니다. Security 400 error를 해결하기 위해 구현해놓았는데 추후 프론트엔드와 연결할 때 필요할 것 같아서 남겨놓았습니다.)
기본적으로 인증/인가 오류의 비슷한 종류들을 전부 400 Bad Request나 500 InternalServer를 반환하게 되어있습니다. 그래서 개발 도중 인증에 대한 오류와 인가에 대한 오류를 구분하기 위해 JwtAccessDeniedHandler(403 Forbidden) 과 JwtAuthenticationEntryPoint(401 UNAUTHORIZED)를 커스텀 필터로 구현하고 적용하였습니다.

그리고 Security 설정을 위한 Security Config 설정을 해놓았습니다. SecurityConfig에 대한 설명은 주석에 자세히 적어놓았으니 확인부탁드립니다.

+ 변경점 및 오류 해결했던 방법

- 우선 기존버전에서는 mariaDB를 사용하였었는데, 지속적으로 401  접근불가 코드가 떠서 DB에서 제대로 저장이 되지 않는다라는 의심이 들었고 비교적 손쉽게 사용가능한 H2로 데이터베이스를 변경하였습니다.

- H2로 변경하고 Security 설정에서 떴던 오류는 서블릿 충돌 오류였습니다. requestMatchers를 사용하여 end point url 허가를 할 것인지 antMatcher 서블릿을 이용한 허가를 할 것인지 하나만 해야했습니다. 자세한건 https://docs.spring.io/spring-security/reference/5.8/migration/servlet/config.html 를 참고해주세요.
그래서 antMatchers를 사용하여 해결하였습니다.




